### PR TITLE
feat: support configured headers as request options

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -90,6 +90,11 @@ class Client
         return $this->httpClient;
     }
 
+    public function getConfig(): Config
+    {
+        return $this->config;
+    }
+
     /**
      * Get S3 client.
      */

--- a/src/Resources/AbstractResource.php
+++ b/src/Resources/AbstractResource.php
@@ -4,6 +4,7 @@ namespace LBausch\CephRadosgwAdmin\Resources;
 
 use LBausch\CephRadosgwAdmin\ApiRequest;
 use LBausch\CephRadosgwAdmin\Client;
+use LBausch\CephRadosgwAdmin\Config;
 use LBausch\CephRadosgwAdmin\Contracts\ResourceContract;
 
 abstract class AbstractResource implements ResourceContract
@@ -18,9 +19,12 @@ abstract class AbstractResource implements ResourceContract
      */
     protected ApiRequest $api;
 
+    protected Config $config;
+
     final public function __construct(Client $client)
     {
         $this->api = ApiRequest::make($client->getHttpClient());
+        $this->config = $client->getConfig();
     }
 
     /**

--- a/src/Resources/Bucket.php
+++ b/src/Resources/Bucket.php
@@ -31,6 +31,7 @@ class Bucket extends AbstractResource
     {
         return $this->api->get($this->endpoint, [
             RequestOptions::QUERY => $data,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -43,6 +44,7 @@ class Bucket extends AbstractResource
     {
         return $this->api->delete($this->endpoint, [
             RequestOptions::QUERY => array_merge(['bucket' => $bucket], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -58,6 +60,7 @@ class Bucket extends AbstractResource
                 'index' => '',
                 'bucket' => $bucket,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -73,6 +76,7 @@ class Bucket extends AbstractResource
                 'bucket' => $bucket,
                 'uid' => $uid,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -88,6 +92,7 @@ class Bucket extends AbstractResource
                 'bucket' => $bucket,
                 'uid' => $uid,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -103,6 +108,7 @@ class Bucket extends AbstractResource
                 'policy' => '',
                 'bucket' => $bucket,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -118,6 +124,7 @@ class Bucket extends AbstractResource
                 'bucket' => $bucket,
                 'object' => $object,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -136,6 +143,7 @@ class Bucket extends AbstractResource
             ],
             RequestOptions::BODY => json_encode($quota),
             AbstractSignature::SIGNATURE_OPTION => SignatureV2::class,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 }

--- a/src/Resources/Usage.php
+++ b/src/Resources/Usage.php
@@ -21,6 +21,7 @@ class Usage extends AbstractResource
     {
         return $this->api->get($this->endpoint, [
             RequestOptions::QUERY => $data,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -33,6 +34,7 @@ class Usage extends AbstractResource
     {
         return $this->api->delete($this->endpoint, [
             RequestOptions::QUERY => $data,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 }

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -33,6 +33,7 @@ class User extends AbstractResource
             RequestOptions::QUERY => [
                 'uid' => $uid,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -48,6 +49,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'display-name' => $displayName,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
             AbstractSignature::SIGNATURE_OPTION => SignatureV2::class,
         ]);
     }
@@ -63,6 +65,7 @@ class User extends AbstractResource
             RequestOptions::QUERY => array_merge([
                 'uid' => $uid,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -78,6 +81,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'purge-data' => $purgeData,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -93,6 +97,7 @@ class User extends AbstractResource
                 'key' => '',
                 'uid' => $uid,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -108,6 +113,7 @@ class User extends AbstractResource
                 'key' => '',
                 'access-key' => $accessKey,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -123,6 +129,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'subuser' => $subuser,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -138,6 +145,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'subuser' => $subuser,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -153,6 +161,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'subuser' => $subuser,
             ], $data),
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -169,6 +178,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'user-caps' => $userCaps,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -185,6 +195,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'user-caps' => $userCaps,
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -201,6 +212,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'quota-type' => 'user',
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -219,6 +231,7 @@ class User extends AbstractResource
             ],
             RequestOptions::BODY => json_encode($quota),
             AbstractSignature::SIGNATURE_OPTION => SignatureV2::class,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -235,6 +248,7 @@ class User extends AbstractResource
                 'uid' => $uid,
                 'quota-type' => 'bucket',
             ],
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 
@@ -253,6 +267,7 @@ class User extends AbstractResource
             ],
             RequestOptions::BODY => json_encode($quota),
             AbstractSignature::SIGNATURE_OPTION => SignatureV2::class,
+            RequestOptions::HEADERS => $this->config->get('httpClientHeaders'),
         ]);
     }
 }


### PR DESCRIPTION
Hello, I came around an issue with the Client Config, for our use case we need to set a `Host` header for ceph rgw different from the base_uri provided for the client constructor, while you can set headers in the config which is then parsed and should be included in the request an alternative Host header has a buggy behaviour and is replaced by the host used as base_uri. 

So I wonder if we could allow to set the headers in each request separately, using headers like this should avoid this bug.

The behaviour is also described in this issue in guzzle (https://github.com/guzzle/guzzle/issues/1297 - marked as solved but reported as still occurring). I realise this might be an edge case but makes sense to me to use the headers config directly like this..